### PR TITLE
Subdirs

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -24,8 +24,6 @@ jobs:
           - {os: ubuntu-16.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
           - {os: ubuntu-16.04,   r: 'oldrel',  rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
           - {os: ubuntu-16.04,   r: '3.5',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
-          - {os: ubuntu-16.04,   r: '3.4',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
-          - {os: ubuntu-16.04,   r: '3.3',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -24,6 +24,8 @@ jobs:
           - {os: ubuntu-16.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
           - {os: ubuntu-16.04,   r: 'oldrel',  rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
           - {os: ubuntu-16.04,   r: '3.5',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
+          - {os: ubuntu-16.04,   r: '3.4',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
+          - {os: ubuntu-16.04,   r: '3.3',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/R/neon_download.R
+++ b/R/neon_download.R
@@ -148,7 +148,7 @@ download_filters <- function(files, file_regex,
   files <- files[grepl(file_regex, files$name), ]
   
   ## create path column for dest
-  files$path <- file.path(dir, files$name)
+  files$path <- neon_subdir(files$name, dir = dir)
   
   ## Filter to have only expanded or basic (not both)
   ## Note: this may not make sense if product is a vector!
@@ -166,6 +166,19 @@ download_filters <- function(files, file_regex,
   files <- take_first_match(files, hash_type(files))
   files
 }
+
+
+## Generate subdir paths and ensure they exist
+neon_subdir <- function(path, dir){
+  df <- neon_filename_parser(basename(path))
+  product <- paste_na(df$DPL, df$PRNUM, df$REV)
+  dirs <- file.path(dir, paste(product, df$SITE, df$YYYY_MM,sep = "/"))
+  lapply(unique(dirs), dir.create, FALSE, TRUE)
+  file.path(dirs, path)
+}
+
+
+
 
 
 hash_type <- function(df){

--- a/R/neon_download_s3.R
+++ b/R/neon_download_s3.R
@@ -36,7 +36,7 @@ neon_download_s3 <- function(product,
                              end_date = NA,
                              site = NA,
                              type = "expanded",
-                             file_regex =  "[.]csv",
+                             file_regex =  "[.]zip",
                              quiet = FALSE,
                              verify = TRUE,
                              dir = neon_dir(), 
@@ -76,7 +76,7 @@ neon_download_s3 <- function(product,
   
   ## URL and destination
   addr <- paste0(api, meta$path)
-  dest <- file.path(dir, meta$path)
+  dest <- neon_subdir(meta$path, dir)
   
   download_all(addr, dest, quiet)
   # verify_hash(dest, files$crc32, verify)

--- a/R/neon_export.R
+++ b/R/neon_export.R
@@ -54,7 +54,10 @@ neon_export <-  function(archive = paste(Sys.Date(), "neonstore.zip", sep="-"),
   }
   
   
-  zip::zipr(archive, meta$path, include_directories=FALSE)
+  zip::zipr(zipfile = archive, 
+            files = meta$path, 
+            root = dir, 
+            include_directories = TRUE)
   invisible(meta)
 }
 

--- a/R/neon_index.R
+++ b/R/neon_index.R
@@ -151,6 +151,10 @@ meta_filter <- function(meta,
     meta <- meta[meta$ext %in% ext, ]
   }
   
+  if(any(is.na(meta$path))){
+    meta <- meta[!is.na(meta$path), ]
+  }
+  
   tibble::as_tibble(meta)
   
 }

--- a/R/neon_index.R
+++ b/R/neon_index.R
@@ -67,15 +67,15 @@ neon_index <- function(product = NA,
                        hash = NULL,
                        dir = neon_dir()){
   
-  files <- list.files(dir)
+  files <- list.files(dir, recursive = TRUE, full.names = TRUE)
   
   ## Turn file names into a metadata table
   meta <- filename_parser(files)
   if(is.null(meta)) return(NULL)
   
   ## Include full paths to files
-  meta$path <- file.path(dir, meta$path)
-  meta$timestamp <-  as.POSIXct(meta$timestamp, format = "%Y%m%dT%H%M%OS")
+  #meta$path <- files
+  meta$timestamp <- as.POSIXct(meta$timestamp, format = "%Y%m%dT%H%M%OS")
   
   ## Apply filters
   meta <- meta_filter(meta, 
@@ -177,7 +177,8 @@ filename_parser <- function(files){
   if(nrow(df) == 0) return(NULL)
   
   ## We may want more columns than this than this.  
-  out <- df[c("SITE", "DESC", "PKGTYPE", "EXT","YYYY_MM",  "GENTIME", "name")]
+  out <- df[c("SITE", "DESC", "PKGTYPE", "EXT","YYYY_MM",  "GENTIME", 
+              "HOR", "VER", "TMI",  "name")]
   out$product <- paste_na(df$DPL, df$PRNUM, df$REV)
   
   ## append type, historical but maybe dumb?
@@ -185,11 +186,15 @@ filename_parser <- function(files){
   
   ## Apply names used originally -- FIXME maybe stick with NEON terms?
   names(out) <- c("site", "table", "type", "ext",
-                  "month", "timestamp", "path", "product")
+                  "month", "timestamp", 
+                  "horizontalPosition", "verticalPosition", "samplingInterval",
+                  "path", "product")
   
   ## re-order
   out <- out[, c("product", "site", "table", "type",
-                 "ext", "month", "timestamp", "path")]
+                 "ext", "month", "timestamp",
+                 "horizontalPosition", "verticalPosition", "samplingInterval",
+                 "path")]
   
   out
 }

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -3,6 +3,7 @@ altrep
 AOP
 api
 bibtex
+bugfix
 CCCCCC
 Codecov
 crc
@@ -21,7 +22,9 @@ FLHTDATE
 FLHTSTRT
 flightline
 FLIGHTSTRT
+g'zipped
 GENTIME
+hdf
 HOR
 horizontalPosition
 http

--- a/man/neon_download_s3.Rd
+++ b/man/neon_download_s3.Rd
@@ -10,7 +10,7 @@ neon_download_s3(
   end_date = NA,
   site = NA,
   type = "expanded",
-  file_regex = "[.]csv",
+  file_regex = "[.]zip",
   quiet = FALSE,
   verify = TRUE,
   dir = neon_dir(),

--- a/tests/testthat/test-additional.R
+++ b/tests/testthat/test-additional.R
@@ -8,7 +8,7 @@ test_that("neon_download_s3()", {
   skip_on_cran()
   skip_if_offline()
   
-  x <- neon_download_s3("DP1.10003.001",
+  x <- neon_download_s3(product = "DP1.10003.001",
                      site = "YELL",
                      start_date = "2018-01-01",
                      end_date = "2019-01-01")

--- a/tests/testthat/test-additional.R
+++ b/tests/testthat/test-additional.R
@@ -63,7 +63,7 @@ test_that("ECdata", {
   skip_if_offline()
   
 
-  x <- neon_download("DP4.00200.001",
+  x <- neon_download(product = "DP4.00200.001",
                      site = "BART",
                      start_date = "2020-06-01",
                      end_date = "2020-07-01",

--- a/tests/testthat/test-store.R
+++ b/tests/testthat/test-store.R
@@ -100,7 +100,7 @@ test_that("filename_parser()", {
 
   meta <- filename_parser(x)
   expect_is(meta, "data.frame")
-  expect_equal(dim(meta), c(7,8))
+  expect_equal(dim(meta), c(7,11))
   
   expect_true(any(grepl("DP1.10003.001", meta$product)))
   expect_true(any(grepl("brd_countdata", meta$table)))
@@ -126,9 +126,19 @@ test_that("neon_citation()", {
 
 test_that("neon_export()/neon_import()", {
   
+  neondir1 <-  tempfile()
+  
+  x <- neon_download(product = "DP1.10003.001",
+                     site = "YELL",
+                     start_date = "2018-05-01",
+                     end_date = "2018-08-01",
+                     dir = neondir1)
+  
+  meta1 <- neon_index(dir = neondir1)
+  
   archive <- tempfile(fileext = ".zip")
   suppressMessages({
-    meta <- neon_export(archive)
+    meta <- neon_export(archive, dir = neondir1)
   })
   
   expect_true(file.exists(archive))
@@ -143,7 +153,7 @@ test_that("neon_export()/neon_import()", {
   neon_import(archive, dir = neondir)
   meta2 <- neon_index(dir = neondir)
   expect_false(is.null(meta2))
-  expect_equal(basename(meta$path), basename(meta2$path))
+  expect_equal(basename(meta1$path), basename(meta2$path))
   
 })
 


### PR DESCRIPTION
Proof of concept for #17, organizing the local store into subdirectories.  This would move from a flat structure to a product/site/month structure.  Maybe a `product/site/` structure would be better?  

A few other minor changes here.  most notably, the HOR/VERT/TMI metadata for sensor data is now exposed by the `neon_index()` table.  

Needs further discussion with @cklunch  how this interfaces with `neonUtilities::stackFromStore` before we do this.  

Probably needs more testing too.  Shouldn't break existing workflows that use `neonstore`'s functions, but will break anything hardwired to assume neonstore is a flat structure. 