### PR TITLE
Patch/hash filter

### DIFF
--- a/R/neon_download.R
+++ b/R/neon_download.R
@@ -226,7 +226,8 @@ type_check <- function(product, type){
 
 # filter files out based on hashes we have already seen
 already_have_hash <- function(files, quiet = FALSE, unique = TRUE, dir = neon_dir()){
-
+  
+  if(!quiet) message("  comparing hashes against local file index...")
   ## Faster to check if IDs are in LMDB then to construct neon_index, but that
   ## would not ensure files actually exist
   index <- neon_index(dir = dir)


### PR DESCRIPTION
- Only filter out matching hashes of files actually present in neon_index()
- Only enter hashes into registry after download, ensuring no entry is created if download is interrupted.