### PR TITLE
handle case of duplicated filenames with differing hashes

### DIFF
--- a/R/neon_db.R
+++ b/R/neon_db.R
@@ -67,7 +67,7 @@ neon_db <- function (dir = neon_db_dir(),
                        ...)
   if(!is.na(memory_limit)){
     pragma <- paste0("PRAGMA memory_limit='", memory_limit, "GB'")
-    DBI::dbExecute(con, pragma)
+    DBI::dbExecute(db, pragma)
   }
 
   if (read_only) {

--- a/R/neon_filename_parser.R
+++ b/R/neon_filename_parser.R
@@ -91,7 +91,10 @@ neon_filename_parser <- function(x){
     schema() # ensure all columns are present
   ))
   #unique(df)
-  df
+  
+  ## enforce original ordering of vector input
+  i <- match(x, df$name)
+  df[i,]
 }
 
 

--- a/R/neon_releases.R
+++ b/R/neon_releases.R
@@ -4,9 +4,11 @@ update_release_manifest <- function(x, dir = neon_dir()){
   if(nrow(x) < 1) return(invisible(NULL))
   x <- x[c("name", "md5", "crc32", "release")]
 
+  # index on name. NOTE: 
   db <- lmdb(dir)
   write_lmdb(db, x$name, x)
   
+  # index on hash
   md5s <- x[!is.na(x$md5),]
   crc32s <- x[!is.na(x$crc32),]
   if(nrow(md5s)>0) write_lmdb(db, md5s$md5, md5s)

--- a/inst/examples/thelio_mirror.R
+++ b/inst/examples/thelio_mirror.R
@@ -1,23 +1,25 @@
 
 library(neonstore)
+options(duckdb_memory_limit=10)
+## Birds
+x <- neon_download("DP1.10003.001")
 
-## birds, beetles, ticks (all sites)
-neon_download("DP1.10003.001")
-neon_download("DP1.10022.001", type = "expanded")
+# Beetles
+neon_download("DP1.10022.001", type = "expanded") 
 
 # Ticks
 tick_sites <- c("BLAN", "ORNL", "SCBI", "SERC", "KONZ", "TALL", "UKFS")
-neon_download_s3("DP1.10093.001", site = tick_sites)
+neon_download("DP1.10093.001", site = tick_sites)
 
 #Terrestrial
 ter_sites <- c("BART", "KONZ", "SRER", "OSBS")
-neonstore::neon_download_s3("DP4.00200.001", table="SWS_30", site = ter_sites, type = "basic")
-neonstore::neon_download_s3("DP1.00094.001", site = ter_sites, type = "basic")
+neonstore::neon_download("DP4.00200.001", table="SWS_30", site = ter_sites, type = "basic")
+neonstore::neon_download("DP1.00094.001", site = ter_sites, type = "basic")
 
 #Aquatic
 aq_sites <- c("BARC", "POSE")
 aq_products <- c("DP1.20053.001","DP1.20288.001", "DP1.20264.001")
-neon_download_s3(aq_products, site = aq_sites, type = "basic")
+neon_download(aq_products, site = aq_sites, type = "basic")
 
 
 ## import into local database

--- a/inst/examples/thelio_mirror.R
+++ b/inst/examples/thelio_mirror.R
@@ -1,23 +1,25 @@
-
+bench::bench_time({
+  
 library(neonstore)
-
+options(duckdb_memory_limit=10)
+  
 ## birds, beetles, ticks (all sites)
-neon_download("DP1.10003.001")
+x <- neon_download("DP1.10003.001")
 neon_download("DP1.10022.001", type = "expanded")
 
 # Ticks
 tick_sites <- c("BLAN", "ORNL", "SCBI", "SERC", "KONZ", "TALL", "UKFS")
-neon_download_s3("DP1.10093.001", site = tick_sites)
+neon_download("DP1.10093.001", site = tick_sites)
 
 #Terrestrial
 ter_sites <- c("BART", "KONZ", "SRER", "OSBS")
-neonstore::neon_download_s3("DP4.00200.001", table="SWS_30", site = ter_sites, type = "basic")
-neonstore::neon_download_s3("DP1.00094.001", site = ter_sites, type = "basic")
+neonstore::neon_download("DP4.00200.001", table="SWS_30", site = ter_sites, type = "basic")
+neonstore::neon_download("DP1.00094.001", site = ter_sites, type = "basic")
 
 #Aquatic
 aq_sites <- c("BARC", "POSE")
 aq_products <- c("DP1.20053.001","DP1.20288.001", "DP1.20264.001")
-neon_download_s3(aq_products, site = aq_sites, type = "basic")
+neon_download(aq_products, site = aq_sites, type = "basic")
 
 
 ## import into local database
@@ -75,3 +77,5 @@ neonstore::neon_store(product = "DP1.20016.001", type = "basic") # Elevation of 
 neonstore::neon_store(product = "DP1.20217.001", type = "basic") # Groundwater temperature
 neonstore::neon_store(product = "DP1.20033.001", type = "basic") # Nitrate
 
+
+})

--- a/man/neon_db.Rd
+++ b/man/neon_db.Rd
@@ -4,7 +4,12 @@
 \alias{neon_db}
 \title{Cache-able duckdb database connection}
 \usage{
-neon_db(dir = neon_db_dir(), read_only = TRUE, ...)
+neon_db(
+  dir = neon_db_dir(),
+  read_only = TRUE,
+  memory_limit = getOption("duckdb_memory_limit", NA),
+  ...
+)
 }
 \arguments{
 \item{dir}{Location where files should be downloaded. By default will
@@ -15,6 +20,12 @@ setting the environmental variable \code{NEONSTORE_HOME}, see \link{Sys.setenv} 
 
 \item{read_only}{allow concurrent connections by enforcing read_only.
 See details.}
+
+\item{memory_limit}{Set a memory limit for duckdb, in GB.  This can
+also be set for the session by using options, e.g.
+\code{options(duckdb_memory_limit=10)} for a limit of 10GB.  On most systems
+duckdb will automatically set a limit to 80\% of machine capacity if not
+set explicitly.}
 
 \item{...}{additional arguments to dbConnect}
 }


### PR DESCRIPTION
sometimes we see the same exact filename for a readme, including the timestamp, but with a different content hash.  (For example: `NEON.D05.STEI.DP1.10003.001.readme.20210123T023002Z.txt`

appears 7 times, all versions have different hashes and appear to be part of the 2021 release:

```
 name                                                    md5                              release     
  <chr>                                                   <chr>                            <chr>       
1 NEON.D05.STEI.DP1.10003.001.readme.20210123T023002Z.txt 54cdd23e5026c80d1680a2b497ea1097 RELEASE-2021
2 NEON.D05.STEI.DP1.10003.001.readme.20210123T023002Z.txt e7651bc854820d18d092dc936c83de45 RELEASE-2021
3 NEON.D05.STEI.DP1.10003.001.readme.20210123T023002Z.txt 37e68f14f93cbc36815e9f7ff9e61b3b RELEASE-2021
4 NEON.D05.STEI.DP1.10003.001.readme.20210123T023002Z.txt 4161a5a0521f47a7d93a750ad84892bd RELEASE-2021
5 NEON.D05.STEI.DP1.10003.001.readme.20210123T023002Z.txt 2333b5352f6fde0a2725ec274a2da74a RELEASE-2021
6 NEON.D05.STEI.DP1.10003.001.readme.20210123T023002Z.txt 954c386f7cc61cd0fdd379ecc04e8916 RELEASE-2021
7 NEON.D05.STEI.DP1.10003.001.readme.20210123T023002Z.txt 2188ebf33db335f9b790e10bf7e048b2 RELEASE-2021
```

For the moment, we will enforce uniqueness of filename before we download, as well as uniqueness of hashes.  Otherwise this will continue to download each of the 7 versions of this file, each overwriting the last; and consecutive calls to `neon_download()` would re-download the other 6.  

- commit also patches a possible bug in `neon_subdir`, by ensuring `neon_filename_parser` preserves `name` order.