### PR TITLE
avoid re-download of .gz files

### DIFF
--- a/R/connection_pane.R
+++ b/R/connection_pane.R
@@ -34,7 +34,7 @@ neon_pane <- function() {
       },
       listColumns = function(table) {
         res <- DBI::dbGetQuery(neon_db(),
-                               paste("SELECT * FROM", table, "LIMIT 1"))
+                               paste0("SELECT * FROM \"", table, "\" LIMIT 1"))
         data.frame(
           name = names(res), 
           type = vapply(res, function(x) class(x)[1], character(1)),
@@ -43,7 +43,7 @@ neon_pane <- function() {
       },
       previewObject = function(rowLimit, table) {  #nolint
         DBI::dbGetQuery(neon_db(),
-                        paste("SELECT * FROM", table, "LIMIT", rowLimit))
+                        paste0("SELECT * FROM \"", table, "\" LIMIT ", rowLimit))
       },
       actions = list(
         Status = list(

--- a/R/neon_download.R
+++ b/R/neon_download.R
@@ -237,7 +237,8 @@ already_have_hash <- function(files, quiet = FALSE, unique = TRUE, dir = neon_di
   ## Also drop name duplicates.  This is dodgy, as these could potentially
   ## have different content. Perhaps we should always overwrite instead.
   ## however, files with same name aren't necessarily newer.
-  name_dups <- gsub(".gz$", "", files$name) %in% stats::na.omit(basename(index$path))
+  names <- gsub(".gz$", "", files$name)
+  name_dups <- files$name %in% stats::na.omit(basename(index$path))
   
   md5_dups <- files$md5 %in% stats::na.omit(index$md5)
   crc32_dups <- files$crc32 %in% stats::na.omit(index$crc32)

--- a/R/neon_download.R
+++ b/R/neon_download.R
@@ -192,10 +192,6 @@ neon_download_ <- function(product,
                verify = verify,
                quiet = quiet)
 
-  
-  if(!quiet && nrow(files) > 0) message("  updating release manifest...")
-  update_release_manifest(x = files, dir = dir)
-
   if(unzip) 
     unzip_all(files$path, dir, keep_zips = TRUE, quiet = quiet)
 
@@ -204,6 +200,8 @@ neon_download_ <- function(product,
   gunzip_all(gzips, dir = dir, quiet = quiet)
 
   
+  if(!quiet && nrow(files) > 0) message("  updating release manifest...")
+  update_release_manifest(x = files, dir = dir) 
     
   ## file metadata (url, path, md5sum)  
   invisible(files)
@@ -239,7 +237,7 @@ already_have_hash <- function(files, quiet = FALSE, unique = TRUE, dir = neon_di
   ## Also drop name duplicates.  This is dodgy, as these could potentially
   ## have different content. Perhaps we should always overwrite instead.
   ## however, files with same name aren't necessarily newer.
-  name_dups <- files$name %in% stats::na.omit(basename(index$path))
+  name_dups <- gsub(".gz$", "", files$name) %in% stats::na.omit(basename(index$path))
   
   md5_dups <- files$md5 %in% stats::na.omit(index$md5)
   crc32_dups <- files$crc32 %in% stats::na.omit(index$crc32)
@@ -353,7 +351,8 @@ safe_download <- function(url, dest, hash = NULL, algo = "md5", verify = TRUE){
     verify_hash(dest, hash, verify, algo)
     },
     error = function(e) 
-      warning(paste(e$message, "on", url),
+      warning(paste(e$message, "on", url, "\n",
+      "Repeat your download request to resume!"),
               call. = FALSE),
     finally = NULL
   )

--- a/R/neon_releases.R
+++ b/R/neon_releases.R
@@ -4,7 +4,15 @@ update_release_manifest <- function(x, dir = neon_dir()){
   if(nrow(x) < 1) return(invisible(NULL))
   x <- x[c("name", "md5", "crc32", "release")]
 
-  # index on name. NOTE: 
+  ## Update gzip hashes with expanded hashes
+  gz <- grepl("[.]gz$", x$name)
+  x$name[gz] <- gsub("\\.gz", "", x$name[gz])
+  gz_path <- gsub("\\.gz", "", neon_subdir(x$name[gz], dir = dir))
+  md5s <- vapply(gz_path, md5, character(1L), USE.NAMES = FALSE)
+  x$md5[gz] <- md5s
+  
+  
+  # index on name
   db <- lmdb(dir)
   write_lmdb(db, x$name, x)
   

--- a/R/neon_releases.R
+++ b/R/neon_releases.R
@@ -4,14 +4,9 @@ update_release_manifest <- function(x, dir = neon_dir()){
   if(nrow(x) < 1) return(invisible(NULL))
   x <- x[c("name", "md5", "crc32", "release")]
 
-  ## Update gzip hashes with expanded hashes
-  gz <- grepl("[.]gz$", x$name)
-  x$name[gz] <- gsub("\\.gz", "", x$name[gz])
-  gz_path <- gsub("\\.gz", "", neon_subdir(x$name[gz], dir = dir))
-  md5s <- vapply(gz_path, md5, character(1L), USE.NAMES = FALSE)
-  x$md5[gz] <- md5s
-  
-  
+  ## Map gzip hashes expanded file-names
+  x$name <- gsub("\\.gz", "", x$name)
+ 
   # index on name
   db <- lmdb(dir)
   write_lmdb(db, x$name, x)

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -104,22 +104,7 @@ gunzip_all <- function(filenames, dir, quiet = FALSE){
   if(length(gzips) > 0){
     destname <- neon_subdir(tools::file_path_sans_ext(gzips), dir = dir)
     mapply(gunzip_, gzips, destname, remove = TRUE, overwrite = TRUE)
-    
-    ## And update the release manifest hashes
-    add_gunzipped_to_manifest(gzips, destname, dir)   
-    
   }
-}
-
-add_gunzipped_to_manifest <- function(gzips, destname, dir){
-  hashes <- vapply(destname, md5, character(1L))
-  
-  manifest <- read_release_manifest(basename(gzips), dir = dir)
-  entries <- data.frame(name = basename(destname), 
-                        md5 = hashes,
-                        crc32 = NA_character_, 
-                        release = manifest$release)
-  update_release_manifest(entries, dir)
 }
 
 ## helper method for filtering out duplicate tables

--- a/inst/examples/thelio_mirror.R
+++ b/inst/examples/thelio_mirror.R
@@ -14,8 +14,8 @@ new_ticks <- neon_download("DP1.10093.001", site = tick_sites)
 
 #Terrestrial
 ter_sites <- c("BART", "KONZ", "SRER", "OSBS")
-new_ter_flux <- neon_download("DP4.00200.001", site = ter_sites) #h5
 new_ter_sw <- neon_download("DP1.00094.001", table = "SWS_30_minute", site = ter_sites)  ## SWS
+new_ter_flux <- neon_download("DP4.00200.001", site = ter_sites) #h5
 
 #Aquatic
 aq_sites <- c("BARC", "POSE")

--- a/tests/testthat/test-additional.R
+++ b/tests/testthat/test-additional.R
@@ -106,6 +106,17 @@ test_that("ECdata", {
   expect_is(x, "data.frame")
   expect_gt(nrow(x), 0)
   
+  ## confirm we omit gz 
+  x <- neon_download(product = "DP4.00200.001",
+                     site = "BART",
+                     start_date = "2020-06-01",
+                     end_date = "2020-07-01",
+                     type = "basic",
+                     dir = dir)
+  expect_equal(nrow(x), 0)
+  
+  
+  
   df <- neon_index(product = "DP4.00200.001",
                    start_date = "2020-06-01",
                    ext = "h5",


### PR DESCRIPTION
Some .gz files would re-download since hashes differed.  