### PR TITLE
Patch: drop deprecated

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: neonstore
 Title: NEON Data Store
-Version: 0.4.0.99
+Version: 0.4.1.99
 Authors@R: c(person(
               "Carl", "Boettiger", 
               email = "cboettig@gmail.com", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# v0.4.2
+
+- Bugfix de-deplication within `neon_store()` [#50]
+
 # v0.4.1
 
 - More robust de-duplication (even if `neon_store()` import terminates prematurely, [#48])

--- a/R/neon_store.R
+++ b/R/neon_store.R
@@ -237,9 +237,9 @@ drop_deprecated <- function(table,
                      product = product,
                      dir = dir, 
                      deprecated = TRUE)
-  key_cols <- c("product", "site", "month", "table", 
-                "verticalPosition", "horizontalPosition")
-  deprecated <- duplicated(meta[key_cols])
+  meta <- flag_deprecated(meta)
+ 
+  deprecated <- meta$deprecated
   
   if(!any(deprecated)){
    return(invisible(NULL))

--- a/R/neon_store.R
+++ b/R/neon_store.R
@@ -222,7 +222,7 @@ split_db_tablename <- function(db_table) {
 
 drop_deprecated <- function(table, 
                             dir = neon_dir(),
-                            con = neon_db()){
+                            con = neon_db(read_only = FALSE)){
   
   if( !(table %in% DBI::dbListTables(con)) ){
     return(invisible(NULL))


### PR DESCRIPTION
Local database could  still get duplicated rows when NEON deprecated data files.  (neon_read() was not impacted).  Fixes issue and shares duplication handling across methods more fully.  